### PR TITLE
Modifies 'result' to be 'builder_result', as it is such a common name, t...

### DIFF
--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -123,19 +123,19 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- (BOOL) has$capitalized_name$ {\n"
-      "  return result.has$capitalized_name$;\n"
+      "  return builder_result.has$capitalized_name$;\n"
       "}\n"
       "- ($type$) $name$ {\n"
-      "  return result.$name$;\n"
+      "  return builder_result.$name$;\n"
       "}\n"
       "- ($classname$_Builder*) set$capitalized_name$:($type$) value {\n"
-      "  result.has$capitalized_name$ = YES;\n"
-      "  result.$name$ = value;\n"
+      "  builder_result.has$capitalized_name$ = YES;\n"
+      "  builder_result.$name$ = value;\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder*) clear$capitalized_name$ {\n"
-      "  result.has$capitalized_name$ = NO;\n"
-      "  result.$name$ = $default$;\n"
+      "  builder_result.has$capitalized_name$ = NO;\n"
+      "  builder_result.$name$ = $default$;\n"
       "  return self;\n"
       "}\n");
   }
@@ -261,7 +261,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 		}else{
 			printer->Print(variables_, "@property (readonly, strong) PBArray * $name$;\n");
 		}
-    
+
   }
 
 
@@ -335,28 +335,28 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void RepeatedEnumFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- (PBAppendableArray *)$name$ {\n"
-      "  return result.$list_name$;\n"
+      "  return builder_result.$list_name$;\n"
       "}\n"
       "- ($type$)$name$AtIndex:(NSUInteger)index {\n"
-      "  return [result $name$AtIndex:index];\n"
+      "  return [builder_result $name$AtIndex:index];\n"
       "}\n"
       "- ($classname$_Builder *)add$capitalized_name$:($type$)value {\n"
-      "  if (result.$list_name$ == nil) {\n"
-      "    result.$list_name$ = [PBAppendableArray arrayWithValueType:PBArrayValueTypeInt32];\n"
+      "  if (builder_result.$list_name$ == nil) {\n"
+      "    builder_result.$list_name$ = [PBAppendableArray arrayWithValueType:PBArrayValueTypeInt32];\n"
       "  }\n"
-      "  [result.$list_name$ addInt32:value];\n"
+      "  [builder_result.$list_name$ addInt32:value];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array {\n"
-      "  result.$list_name$ = [PBAppendableArray arrayWithArray:array valueType:PBArrayValueTypeInt32];\n"
+      "  builder_result.$list_name$ = [PBAppendableArray arrayWithArray:array valueType:PBArrayValueTypeInt32];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)set$capitalized_name$Values:(const $type$ *)values count:(NSUInteger)count {\n"
-      "  result.$list_name$ = [PBAppendableArray arrayWithValues:values count:count valueType:PBArrayValueTypeInt32];\n"
+      "  builder_result.$list_name$ = [PBAppendableArray arrayWithValues:values count:count valueType:PBArrayValueTypeInt32];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)clear$capitalized_name$ {\n"
-      "  result.$list_name$ = nil;\n"
+      "  builder_result.$list_name$ = nil;\n"
       "  return self;\n"
       "}\n");
   }
@@ -364,10 +364,10 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void RepeatedEnumFieldGenerator::GenerateMergingCodeSource(io::Printer* printer) const {
     printer->Print(variables_,
       "if (other.$list_name$.count > 0) {\n"
-      "  if (result.$list_name$ == nil) {\n"
-      "    result.$list_name$ = [other.$list_name$ copy];\n"
+      "  if (builder_result.$list_name$ == nil) {\n"
+      "    builder_result.$list_name$ = [other.$list_name$ copy];\n"
       "  } else {\n"
-      "    [result.$list_name$ appendArray:other.$list_name$];\n"
+      "    [builder_result.$list_name$ appendArray:other.$list_name$];\n"
       "  }\n"
       "}\n");
   }

--- a/src/compiler/objc_helpers.cc
+++ b/src/compiler/objc_helpers.cc
@@ -537,25 +537,25 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
  bool isObjectArray(const FieldDescriptor* field){
 	 switch (field->type()) {
-		  case FieldDescriptor::TYPE_STRING  : 
-	      case FieldDescriptor::TYPE_BYTES   : 
-	      case FieldDescriptor::TYPE_GROUP   : 
+		  case FieldDescriptor::TYPE_STRING  :
+	      case FieldDescriptor::TYPE_BYTES   :
+	      case FieldDescriptor::TYPE_GROUP   :
 	      case FieldDescriptor::TYPE_MESSAGE : return true;
-	      case FieldDescriptor::TYPE_ENUM    : 
-	      case FieldDescriptor::TYPE_INT32   : 
+	      case FieldDescriptor::TYPE_ENUM    :
+	      case FieldDescriptor::TYPE_INT32   :
 	      case FieldDescriptor::TYPE_UINT32  :
 	      case FieldDescriptor::TYPE_SINT32  :
 	      case FieldDescriptor::TYPE_FIXED32 :
 	      case FieldDescriptor::TYPE_SFIXED32:
 	      case FieldDescriptor::TYPE_INT64   :
-	      case FieldDescriptor::TYPE_UINT64  : 
-	      case FieldDescriptor::TYPE_SINT64  : 
-	      case FieldDescriptor::TYPE_FIXED64 : 
-	      case FieldDescriptor::TYPE_SFIXED64: 
+	      case FieldDescriptor::TYPE_UINT64  :
+	      case FieldDescriptor::TYPE_SINT64  :
+	      case FieldDescriptor::TYPE_FIXED64 :
+	      case FieldDescriptor::TYPE_SFIXED64:
 	      case FieldDescriptor::TYPE_FLOAT   :
 	      case FieldDescriptor::TYPE_DOUBLE  :
 	      case FieldDescriptor::TYPE_BOOL    : return false  ;
-	      
+
 	    }
 	    GOOGLE_LOG(FATAL) << "Can't get here.";
 	    return NULL;

--- a/src/compiler/objc_message.cc
+++ b/src/compiler/objc_message.cc
@@ -466,7 +466,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
     printer->Print(
       "@private\n"
-      "  $classname$* result;\n"
+      "  $classname$* builder_result;\n"
       "}\n",
       "classname", ClassName(descriptor_));
 
@@ -827,17 +827,17 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void MessageGenerator::GenerateBuilderSource(io::Printer* printer) {
     printer->Print(
       "@interface $classname$_Builder()\n"
-      "@property (strong) $classname$* result;\n"
+      "@property (strong) $classname$* builder_result;\n"
       "@end\n"
       "\n"
       "@implementation $classname$_Builder\n"
-      "@synthesize result;\n",
+      "@synthesize builder_result;\n",
       "classname", ClassName(descriptor_));
 
     printer->Print(
       "- (id) init {\n"
       "  if ((self = [super init])) {\n"
-      "    self.result = [[$classname$ alloc] init];\n"
+      "    self.builder_result = [[$classname$ alloc] init];\n"
       "  }\n"
       "  return self;\n"
       "}\n",
@@ -858,22 +858,22 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
     if (descriptor_->extension_range_count() > 0) {
       printer->Print(
       "- (PBExtendableMessage*) internalGetResult {\n"
-      "  return result;\n"
+      "  return builder_result;\n"
       "}\n");
     } else {
       printer->Print(
       "- (PBGeneratedMessage*) internalGetResult {\n"
-      "  return result;\n"
+      "  return builder_result;\n"
       "}\n");
     }
 
     printer->Print(
       "- ($classname$_Builder*) clear {\n"
-      "  self.result = [[$classname$ alloc] init];\n"
+      "  self.builder_result = [[$classname$ alloc] init];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder*) clone {\n"
-      "  return [$classname$ builderWithPrototype:result];\n"
+      "  return [$classname$ builderWithPrototype:builder_result];\n"
       "}\n"
       "- ($classname$*) defaultInstance {\n"
       "  return [$classname$ defaultInstance];\n"
@@ -895,8 +895,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
     printer->Outdent();
     printer->Print(
-      "  $classname$* returnMe = result;\n"
-      "  self.result = nil;\n"
+      "  $classname$* returnMe = builder_result;\n"
+      "  self.builder_result = nil;\n"
       "  return returnMe;\n"
       "}\n",
       "classname", ClassName(descriptor_));

--- a/src/compiler/objc_message_field.cc
+++ b/src/compiler/objc_message_field.cc
@@ -125,33 +125,33 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void MessageFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- (BOOL) has$capitalized_name$ {\n"
-      "  return result.has$capitalized_name$;\n"
+      "  return builder_result.has$capitalized_name$;\n"
       "}\n"
       "- ($storage_type$) $name$ {\n"
-      "  return result.$name$;\n"
+      "  return builder_result.$name$;\n"
       "}\n"
       "- ($classname$_Builder*) set$capitalized_name$:($storage_type$) value {\n"
-      "  result.has$capitalized_name$ = YES;\n"
-      "  result.$name$ = value;\n"
+      "  builder_result.has$capitalized_name$ = YES;\n"
+      "  builder_result.$name$ = value;\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder*) set$capitalized_name$Builder:($type$_Builder*) builderForValue {\n"
       "  return [self set$capitalized_name$:[builderForValue build]];\n"
       "}\n"
       "- ($classname$_Builder*) merge$capitalized_name$:($storage_type$) value {\n"
-      "  if (result.has$capitalized_name$ &&\n"
-      "      result.$name$ != [$type$ defaultInstance]) {\n"
-      "    result.$name$ =\n"
-      "      [[[$type$ builderWithPrototype:result.$name$] mergeFrom:value] buildPartial];\n"
+      "  if (builder_result.has$capitalized_name$ &&\n"
+      "      builder_result.$name$ != [$type$ defaultInstance]) {\n"
+      "    builder_result.$name$ =\n"
+      "      [[[$type$ builderWithPrototype:builder_result.$name$] mergeFrom:value] buildPartial];\n"
       "  } else {\n"
-      "    result.$name$ = value;\n"
+      "    builder_result.$name$ = value;\n"
       "  }\n"
-      "  result.has$capitalized_name$ = YES;\n"
+      "  builder_result.has$capitalized_name$ = YES;\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder*) clear$capitalized_name$ {\n"
-      "  result.has$capitalized_name$ = NO;\n"
-      "  result.$name$ = [$type$ defaultInstance];\n"
+      "  builder_result.has$capitalized_name$ = NO;\n"
+      "  builder_result.$name$ = [$type$ defaultInstance];\n"
       "  return self;\n"
       "}\n");
   }
@@ -357,31 +357,31 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 		      "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array;\n"
 		      "- ($classname$_Builder *)set$capitalized_name$Values:(const $storage_type$ *)values count:(NSUInteger)count;\n"
 		      "- ($classname$_Builder *)clear$capitalized_name$;\n");
-		
+
 		}
   }
 
   void RepeatedMessageFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- (NSMutableArray *)$name$ {\n"
-      "  return result.$list_name$;\n"
+      "  return builder_result.$list_name$;\n"
       "}\n"
       "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-      "  return [result $name$AtIndex:index];\n"
+      "  return [builder_result $name$AtIndex:index];\n"
       "}\n"
       "- ($classname$_Builder *)add$capitalized_name$:($storage_type$)value {\n"
-      "  if (result.$list_name$ == nil) {\n"
-      "    result.$list_name$ = [[NSMutableArray alloc]init];\n"
+      "  if (builder_result.$list_name$ == nil) {\n"
+      "    builder_result.$list_name$ = [[NSMutableArray alloc]init];\n"
       "  }\n"
-      "  [result.$list_name$ addObject:value];\n"
+      "  [builder_result.$list_name$ addObject:value];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array {\n"
-      "  result.$list_name$ = [[NSMutableArray alloc]initWithArray:array];\n"
+      "  builder_result.$list_name$ = [[NSMutableArray alloc]initWithArray:array];\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder *)clear$capitalized_name$ {\n"
-      "  result.$list_name$ = nil;\n"
+      "  builder_result.$list_name$ = nil;\n"
       "  return self;\n"
       "}\n");
   }
@@ -412,22 +412,22 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 	if(isObjectArray(descriptor_)){
 		printer->Print(variables_,
 	      "if (other.$list_name$.count > 0) {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [[NSMutableArray alloc] initWithArray:other.$list_name$];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [[NSMutableArray alloc] initWithArray:other.$list_name$];\n"
 	      "  } else {\n"
-	      "    [result.$list_name$ addObjectsFromArray:other.$list_name$];\n"
+	      "    [builder_result.$list_name$ addObjectsFromArray:other.$list_name$];\n"
 	      "  }\n"
       	  "}\n");
 	}else{
 		printer->Print(variables_,
 	      "if (other.$list_name$.count > 0) {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [other.$list_name$ copy];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [other.$list_name$ copy];\n"
 	      "  } else {\n"
-	      "    [result.$list_name$ appendArray:other.$list_name$];\n"
+	      "    [builder_result.$list_name$ appendArray:other.$list_name$];\n"
 	      "  }\n"
       	  "}\n");
-    	
+
 	}
   }
 

--- a/src/compiler/objc_primitive_field.cc
+++ b/src/compiler/objc_primitive_field.cc
@@ -197,8 +197,8 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 			(*variables)["array_value_type_name"] = GetArrayValueTypeName(descriptor);
 			 (*variables)["array_value_type_name_cap"] = GetCapitalizedArrayValueTypeName(descriptor);
 		}
-        
-       
+
+
 
         (*variables)["default"] = DefaultValue(descriptor);
         (*variables)["capitalized_type"] = GetCapitalizedType(descriptor);
@@ -336,19 +336,19 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void PrimitiveFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- (BOOL) has$capitalized_name$ {\n"
-      "  return result.has$capitalized_name$;\n"
+      "  return builder_result.has$capitalized_name$;\n"
       "}\n"
       "- ($storage_type$) $name$ {\n"
-      "  return result.$name$;\n"
+      "  return builder_result.$name$;\n"
       "}\n"
       "- ($classname$_Builder*) set$capitalized_name$:($storage_type$) value {\n"
-      "  result.has$capitalized_name$ = YES;\n"
-      "  result.$name$ = value;\n"
+      "  builder_result.has$capitalized_name$ = YES;\n"
+      "  builder_result.$name$ = value;\n"
       "  return self;\n"
       "}\n"
       "- ($classname$_Builder*) clear$capitalized_name$ {\n"
-      "  result.has$capitalized_name$ = NO;\n"
-      "  result.$name$ = $default$;\n"
+      "  builder_result.has$capitalized_name$ = NO;\n"
+      "  builder_result.$name$ = $default$;\n"
       "  return self;\n"
       "}\n");
   }
@@ -539,7 +539,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 	      "}\n"
 	      "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
 	      "  return [$list_name$ $array_value_type_name$AtIndex:index];\n"
-	      "}\n");		
+	      "}\n");
 	}
   }
 
@@ -548,51 +548,51 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 	if(isObjectArray(descriptor_)){
 		printer->Print(variables_,
 	      "- (NSMutableArray *)$name$ {\n"
-	      "  return result.$list_name$;\n"
+	      "  return builder_result.$list_name$;\n"
 	      "}\n"
 	      "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-	      "  return [result $name$AtIndex:index];\n"
+	      "  return [builder_result $name$AtIndex:index];\n"
 	      "}\n"
 	      "- ($classname$_Builder *)add$capitalized_name$:($storage_type$)value {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [[NSMutableArray alloc]init];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [[NSMutableArray alloc]init];\n"
 	      "  }\n"
-	      "  [result.$list_name$ addObject:value];\n"
+	      "  [builder_result.$list_name$ addObject:value];\n"
 	      "  return self;\n"
 	      "}\n"
 	      "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array {\n"
-	      "  result.$list_name$ = [[NSMutableArray alloc] initWithArray:array];\n"
+	      "  builder_result.$list_name$ = [[NSMutableArray alloc] initWithArray:array];\n"
 	      "  return self;\n"
 	      "}\n"
 	      "- ($classname$_Builder *)clear$capitalized_name$ {\n"
-	      "  result.$list_name$ = nil;\n"
+	      "  builder_result.$list_name$ = nil;\n"
 	      "  return self;\n"
 	      "}\n");
 	}else{
 	    printer->Print(variables_,
 	      "- (PBAppendableArray *)$name$ {\n"
-	      "  return result.$list_name$;\n"
+	      "  return builder_result.$list_name$;\n"
 	      "}\n"
 	      "- ($storage_type$)$name$AtIndex:(NSUInteger)index {\n"
-	      "  return [result $name$AtIndex:index];\n"
+	      "  return [builder_result $name$AtIndex:index];\n"
 	      "}\n"
 	      "- ($classname$_Builder *)add$capitalized_name$:($storage_type$)value {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [PBAppendableArray arrayWithValueType:$array_value_type$];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [PBAppendableArray arrayWithValueType:$array_value_type$];\n"
 	      "  }\n"
-	      "  [result.$list_name$ add$array_value_type_name_cap$:value];\n"
+	      "  [builder_result.$list_name$ add$array_value_type_name_cap$:value];\n"
 	      "  return self;\n"
 	      "}\n"
 	      "- ($classname$_Builder *)set$capitalized_name$Array:(NSArray *)array {\n"
-	      "  result.$list_name$ = [PBAppendableArray arrayWithArray:array valueType:$array_value_type$];\n"
+	      "  builder_result.$list_name$ = [PBAppendableArray arrayWithArray:array valueType:$array_value_type$];\n"
 	      "  return self;\n"
 	      "}\n"
 	      "- ($classname$_Builder *)set$capitalized_name$Values:(const $storage_type$ *)values count:(NSUInteger)count {\n"
-	      "  result.$list_name$ = [PBAppendableArray arrayWithValues:values count:count valueType:$array_value_type$];\n"
+	      "  builder_result.$list_name$ = [PBAppendableArray arrayWithValues:values count:count valueType:$array_value_type$];\n"
 	      "  return self;\n"
 	      "}\n"
 	      "- ($classname$_Builder *)clear$capitalized_name$ {\n"
-	      "  result.$list_name$ = nil;\n"
+	      "  builder_result.$list_name$ = nil;\n"
 	      "  return self;\n"
 	      "}\n");
 		}
@@ -603,19 +603,19 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 	if(isObjectArray(descriptor_)){
    	 printer->Print(variables_,
 	      "if (other.$list_name$.count > 0) {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [[NSMutableArray alloc] initWithArray:other.$list_name$];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [[NSMutableArray alloc] initWithArray:other.$list_name$];\n"
 	      "  } else {\n"
-	      "    [result.$list_name$ addObjectsFromArray:other.$list_name$];\n"
+	      "    [builder_result.$list_name$ addObjectsFromArray:other.$list_name$];\n"
 	      "  }\n"
 	      "}\n");
 	}else{
    	 printer->Print(variables_,
 	      "if (other.$list_name$.count > 0) {\n"
-	      "  if (result.$list_name$ == nil) {\n"
-	      "    result.$list_name$ = [other.$list_name$ copy];\n"
+	      "  if (builder_result.$list_name$ == nil) {\n"
+	      "    builder_result.$list_name$ = [other.$list_name$ copy];\n"
 	      "  } else {\n"
-	      "    [result.$list_name$ appendArray:other.$list_name$];\n"
+	      "    [builder_result.$list_name$ appendArray:other.$list_name$];\n"
 	      "  }\n"
 	      "}\n");
 	}
@@ -633,11 +633,11 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 	      printer->Print(variables_,
 	        "int32_t length = [input readRawVarint32];\n"
 	        "int32_t limit = [input pushLimit:length];\n"
-	        "if (result.$list_name$ == nil) {\n"
-	        "  result.$list_name$ = [[NSMutableArray alloc]init];\n"
+	        "if (builder_result.$list_name$ == nil) {\n"
+	        "  builder_result.$list_name$ = [[NSMutableArray alloc]init];\n"
 	        "}\n"
 	        "while (input.bytesUntilLimit > 0) {\n"
-	        "  [result.$list_name$ addObject:[input read$capitalized_type$]];\n"
+	        "  [builder_result.$list_name$ addObject:[input read$capitalized_type$]];\n"
 	        "}\n"
 	        "[input popLimit:limit];\n");
 		}
@@ -645,11 +645,11 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 			printer->Print(variables_,
 		        "int32_t length = [input readRawVarint32];\n"
 		        "int32_t limit = [input pushLimit:length];\n"
-		        "if (result.$list_name$ == nil) {\n"
-		        "  result.$list_name$ = [PBAppendableArray arrayWithValueType:$array_value_type$];\n"
+		        "if (builder_result.$list_name$ == nil) {\n"
+		        "  builder_result.$list_name$ = [PBAppendableArray arrayWithValueType:$array_value_type$];\n"
 		        "}\n"
 		        "while (input.bytesUntilLimit > 0) {\n"
-		        "  [result.$list_name$ add$array_value_type_name_cap$:[input read$capitalized_type$]];\n"
+		        "  [builder_result.$list_name$ add$array_value_type_name_cap$:[input read$capitalized_type$]];\n"
 		        "}\n"
 		        "[input popLimit:limit];\n");
 		}


### PR DESCRIPTION
Very commonn name for the internal 'result' of a builder.
Changed the property to be named builder_result, so it is really harder that any protobuf field will be named builder_result.

The problem was spotted when compiling Hotpanel protocol:
http://mobiledoc.badoojira.com/_downloads/hotpanel.proto

There are fields in messages called 'result'. These clash with the 'result' in builder, so generated code does not compile.
