### PR TITLE
Uses int32_t as the storage type for enumerations 

### DIFF
--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -23,7 +23,7 @@ using namespace google::protobuf::compiler::objectivec;
 int main(int argc, char **argv)
 {
 	if (argc == 2 && strcmp(argv[1], "-version") == 0) {
-		std::cout << "1.0.0" << std::endl;
+		std::cout << "1.0.1" << std::endl;
 		exit(0);
 	}
 

--- a/src/compiler/objc_enum.cc
+++ b/src/compiler/objc_enum.cc
@@ -52,7 +52,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
   void EnumGenerator::GenerateHeader(io::Printer* printer) {
     printer->Print(
-      "typedef NS_ENUM(NSInteger, $classname$) {\n",
+      "typedef NS_ENUM(int32_t, $classname$) {\n",
       "classname", ClassName(descriptor_)
     );
     printer->Indent();


### PR DESCRIPTION
It's the one the protobuf serializer assumes