### PR TITLE
Add an assertion for invalid enum values

### DIFF
--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -23,7 +23,7 @@ using namespace google::protobuf::compiler::objectivec;
 int main(int argc, char **argv)
 {
 	if (argc == 2 && strcmp(argv[1], "-version") == 0) {
-		std::cout << "1.1.2" << std::endl;
+		std::cout << "1.1.3" << std::endl;
 		exit(0);
 	}
 

--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -131,6 +131,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- ($classname$_Builder*)set$capitalized_name$:($type$) value {\n"
+      "  NSAssert($type$IsValidValue(value), @\"The value '%d' is invalid for $type$\", value);\n"
       "  builder_result.has$capitalized_name$ = YES;\n"
       "  builder_result.$name$ = value;\n"
       "  return self;\n"

--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -131,7 +131,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- ($classname$_Builder*)set$capitalized_name$:($type$) value {\n"
-      "  NSAssert($type$IsValidValue(value), @\"The value '%d' is invalid for $type$\", value);\n"
+      "  BPFAssert($type$IsValidValue(value), @\"The value '%d' is invalid for $type$\", value);\n"
       "  builder_result.has$capitalized_name$ = YES;\n"
       "  builder_result.$name$ = value;\n"
       "  return self;\n"


### PR DESCRIPTION
### The main goal is to protect all proto setters for enums from invalid values.

As you can see, we can use `BPFAssert` in this case with one remark: we will be forced to populate `prefix.pch` with an explicit import of `BPFAssert.h` from `BPPlatform_Foundation` framework to avoid the error related to the implicit declaration rules for C99. For example, we have to update `.podspec` for `BPPlatform_Network` with something like this:

```podspec
...
  s.prefix_header_contents = '''
  #ifdef __OBJC__
  #import <BPPlatform_Foundation/BPFAssert.h>
  #endif
  '''
...
```

The result of the generation will look like this:
```objectivec 
- (BMServerUserVerify_Builder*)setVerifyForPaymentProvider:(BMPaymentProviderType) value {
   BPFAssert(BMPaymentProviderTypeIsValidValue(value), @"The value '%d' is invalid for BMPaymentProviderType", value);
   builder_result.hasVerifyForPaymentProvider = YES;
   builder_result.verifyForPaymentProvider = value;
   return self;
 }
```

The fired assert will look like this in Log Viewer:
```
... 16:57:36.056 ASSERTION FAILURE: The value '0' is invalid for BMPermissionType   
*** Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Assertion failure in *.pb.m:218478 -[BMPermissionAcceptanceStats_Builder setType:]. The value '0' is invalid for BMPermissionType'
*** First throw call stack:
...
```
  