### PR TITLE
Prepare the protobuf-objc to Proto.framework

### DIFF
--- a/src/compiler/main.cc
+++ b/src/compiler/main.cc
@@ -23,7 +23,7 @@ using namespace google::protobuf::compiler::objectivec;
 int main(int argc, char **argv)
 {
 	if (argc == 2 && strcmp(argv[1], "-version") == 0) {
-		std::cout << "1.1.3" << std::endl;
+		std::cout << "1.1.4" << std::endl;
 		exit(0);
 	}
 

--- a/src/compiler/objc_enum_field.cc
+++ b/src/compiler/objc_enum_field.cc
@@ -131,7 +131,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
   void EnumFieldGenerator::GenerateBuilderMembersSource(io::Printer* printer) const {
     printer->Print(variables_,
       "- ($classname$_Builder*)set$capitalized_name$:($type$) value {\n"
-      "  BPFAssert($type$IsValidValue(value), @\"The value '%d' is invalid for $type$\", value);\n"
+      "  NSAssert($type$IsValidValue(value), @\"The value '%d' is invalid for $type$\", value);\n"
       "  builder_result.has$capitalized_name$ = YES;\n"
       "  builder_result.$name$ = value;\n"
       "  return self;\n"

--- a/src/compiler/objc_file.cc
+++ b/src/compiler/objc_file.cc
@@ -50,12 +50,12 @@ namespace google { namespace protobuf { namespace compiler {namespace objectivec
           // hacky.  but this is how other generators determine if we're generating
           // the core ProtocolBuffers library
           if (file_->name() != "google/protobuf/descriptor.proto") {
-  			       printer->Print("#import <BPPlatform_Network/ProtocolBuffers.h>\n");
+  			       printer->Print("#import <Proto/ProtocolBuffers.h>\n");
           }
 
           if (file_->dependency_count() > 0) {
               for (int i = 0; i < file_->dependency_count(); i++) {
-                  printer->Print("#import <BPPlatform_Network/$header$.pb.h>\n", "header", FilePath(file_->dependency(i)));
+                  printer->Print("#import <Proto/$header$.pb.h>\n", "header", FilePath(file_->dependency(i)));
               }
               printer->Print("\n");
           }


### PR DESCRIPTION
- Switched back to NSAssert instead of BPFAssert: we want to extract `proto` functionality into a separate module without any 3rd party dependencies, so let's switch to `NSAssert` as we agreed before.
- Changed hardcoded prefixes 