### PR TITLE
Migration to NS_CLOSED_ENUM by default

### DIFF
--- a/src/compiler/objc_enum.cc
+++ b/src/compiler/objc_enum.cc
@@ -52,7 +52,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
 
   void EnumGenerator::GenerateHeader(io::Printer* printer) {
     printer->Print(
-      "typedef NS_ENUM(int32_t, $classname$) {\n",
+      "typedef NS_CLOSED_ENUM(int32_t, $classname$) {\n",
       "classname", ClassName(descriptor_)
     );
     printer->Indent();


### PR DESCRIPTION
To support the migration process to Swift 5.1 we have to define all our internal enums as closed (frozen) to avoid redundant `@unknown default` statements in our code base.