### PR TITLE
Added support for the tag [required=true] in comments

### DIFF
--- a/src/compiler/objc_message.cc
+++ b/src/compiler/objc_message.cc
@@ -106,6 +106,18 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       return "static_" + StringReplace(descriptor->full_name(), ".", "_", true);
     }
 
+    // Returns true if the field has [required=true] flag
+    static bool HasRequiredTag(const FieldDescriptor *field) {
+      SourceLocation source;
+      bool has_source_location = field->GetSourceLocation(&source);
+      if (!has_source_location) {
+        return false;
+      }
+
+      std::string comments = source.trailing_comments;
+      return comments.find("[required=true]") != std::string::npos;
+    }
+
     // Returns true if the message type has any required fields.  If it doesn't,
     // we can optimize out calls to its isInitialized() method.
     //
@@ -137,6 +149,9 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
         for (int i = 0; i < type->field_count(); i++) {
           const FieldDescriptor* field = type->field(i);
           if (field->is_required()) {
+            return true;
+          }
+          if (HasRequiredTag(field)) {
             return true;
           }
           if (field->cpp_type() == FieldDescriptor::CPPTYPE_MESSAGE) {
@@ -1010,7 +1025,7 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
           "}\n",
           "capitalized_name", UnderscoresToCapitalizedCamelCase(field));
       } else {
-        GenerateRequiredFieldCheckSource(printer, field);
+        GenerateRequiredFieldCheckSourceIfNeeded(printer, field);
       }
     }
 
@@ -1033,12 +1048,19 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
                 "}\n");
               break;
             case FieldDescriptor::LABEL_OPTIONAL:
-              printer->Print(vars,
-                "if (self.has$capitalized_name$) {\n"
-                "  if (!self.$name$.isInitialized) {\n"
-                "    return NO;\n"
-                "  }\n"
-                "}\n");
+              if (HasRequiredTag(field)) {
+                printer->Print(vars,
+                  "if (!self.$name$.isInitialized) {\n"
+                  "  return NO;\n"
+                  "}\n");
+              } else {
+                printer->Print(vars,
+                  "if (self.has$capitalized_name$) {\n"
+                  "  if (!self.$name$.isInitialized) {\n"
+                  "    return NO;\n"
+                  "  }\n"
+                  "}\n");
+              }
               break;
             case FieldDescriptor::LABEL_REPEATED:
               printer->Print(vars,
@@ -1065,15 +1087,9 @@ namespace google { namespace protobuf { namespace compiler { namespace objective
       "}\n");
   }
 
-  void MessageGenerator::GenerateRequiredFieldCheckSource(
+  void MessageGenerator::GenerateRequiredFieldCheckSourceIfNeeded(
     io::Printer* printer, const FieldDescriptor* field) {
-    SourceLocation source;
-    bool has_source_location = field->GetSourceLocation(&source);
-    if (!has_source_location) { return; }
-
-    std::string comments = source.trailing_comments;
-    bool has_required_tag = comments.find("[required=true]") != std::string::npos;
-    if (!has_required_tag) { return; }
+    if (!HasRequiredTag(field)) { return; }
 
     map<string,string> vars;
     vars["capitalized_name"] = UnderscoresToCapitalizedCamelCase(field);

--- a/src/compiler/objc_message.h
+++ b/src/compiler/objc_message.h
@@ -94,6 +94,8 @@ class MessageGenerator {
   void GenerateBuilderParsingMethodsSource(io::Printer* printer);
   void GenerateBuilderPartiallyMergeMethodSource(io::Printer* printer);
   void GenerateIsInitializedSource(io::Printer* printer);
+  void GenerateRequiredFieldCheckSource(
+    io::Printer* printer,const FieldDescriptor* field);
 
   const Descriptor* descriptor_;
   FieldGeneratorMap field_generators_;

--- a/src/compiler/objc_message.h
+++ b/src/compiler/objc_message.h
@@ -94,7 +94,7 @@ class MessageGenerator {
   void GenerateBuilderParsingMethodsSource(io::Printer* printer);
   void GenerateBuilderPartiallyMergeMethodSource(io::Printer* printer);
   void GenerateIsInitializedSource(io::Printer* printer);
-  void GenerateRequiredFieldCheckSource(
+  void GenerateRequiredFieldCheckSourceIfNeeded(
     io::Printer* printer,const FieldDescriptor* field);
 
   const Descriptor* descriptor_;


### PR DESCRIPTION
# Motivation
We are migrating to Protobuf v3 and as a first step we make Profobuf v2 spec compatible with the third version.
In order to to this, we have to make all fields optional. But at the same time, some fields still are required by the protocol of communication between the server and client. Hence we adding the support of the custom flag which indicated that the field is required.

# Implementation
The tag is just a part of a trailing comment of the field in the Protobuf specification. For example:
```
message Message {
    optional int32 id; // [required=true]
}
```

In the code generator, if the field is not required we check for this tag in the comment and add additional checks in `- (BOOL) isInitialized` method.
If the field is repeated, the tag still could be be present, so I also added the nullability check for this case.

# What it changes in the generated code
If the [required=true] flag is present in fields that marked as required by the Protobuf spec, nothing changes.
If the [required=true] flag is replacing the required keyword of the field, also nothing should change because semantically nothing is changed.
### Before
What checks were before in case of required
```
// check of the field itself
if (!self.hasSomeRequiredField()) {
    return NO;
}

// check the state of the nested message
if (!self.someRequiredField.isInitialized) {
    return NO;
}
```
Optional:
```
// check the state of the nested message
if (self.hasSomeRequiredField()) {
   if (!self.someField.isInitialized) {
       return NO;
   }
}
```
### After
Adding checks in the codegenerator ensures that the behaviour for the required field is applied for the optional fields with [required=true] tag.
